### PR TITLE
Add nolist and remove colorcolumn from man pages

### DIFF
--- a/plugin/superman.vim
+++ b/plugin/superman.vim
@@ -32,6 +32,8 @@ function! superman#SuperMan(...)
   setlocal tabstop=8
   setlocal softtabstop=8
   setlocal shiftwidth=8
+  setlocal nolist
+  setlocal colorcolumn=0
 
   " To make us behave more like less
   noremap q :q<CR>


### PR DESCRIPTION
This change simply makes the display of man pages a bit more pleasant by not showing `listchars` (tabs, eol etc.) and removing the `colorcolumn`.