### PR TITLE
Support for custom man.vim

### DIFF
--- a/plugin/superman.vim
+++ b/plugin/superman.vim
@@ -9,8 +9,10 @@
 
 " Wrapper around man.vim's Man command
 function! superman#SuperMan(...)
-  " Needed to get access to Man
-  source $VIMRUNTIME/ftplugin/man.vim
+  if exists(":Man") != 2 " No :Man command defined
+    " Needed to get access to Man
+    source $VIMRUNTIME/ftplugin/man.vim
+  endif
 
   " Build and pass off arguments to Man command
   execute 'Man' join(a:000, ' ')


### PR DESCRIPTION
Small tweak to allow the use of another man ftplugin. For example, I use [bruno-/vim-man](https://github.com/bruno-/vim-man), which is actually the stock **man.vim** included with Vim with enhancements. The addition of the conditional simply skips sourcing `$VIMRUNTIME/ftplugin/man.vim` if the `:Man` command is already defined.

Coincidentally, an [identical conditional](https://github.com/b4winckler/vim/blob/master/runtime/ftplugin/man.vim#L42) exists in the stock **man.vim** when defining the `:Man` command.